### PR TITLE
Update install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,4 +183,4 @@ Visit [Releases](https://github.com/yamnikov-oleg/nasmfmt/releases) to download 
 
 Building requires latest version of golang from [golang.org](https://golang.org/).
 
-If you installed one, run `go get -u github.com/yamnikov-oleg/nasmfmt`. Built binary will be located in your $GOPATH/bin.
+If you installed one, run `go install github.com/yamnikov-oleg/nasmfmt@latest`. Built binary will be located in your $GOPATH/bin.


### PR DESCRIPTION
Fixes 

$ go get -u github.com/yamnikov-oleg/nasmfmt
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.